### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ MCP (Model Context Protocol) server for LM Studio that provides tools for intern
 - fetch_url: performs HTTP GET and returns content-type and body (limited)
 - extract_readable: extracts the main readable content from a page
 
+<a href="https://glama.ai/mcp/servers/@JoaoPedroLanca/mcp-web-tools">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@JoaoPedroLanca/mcp-web-tools/badge" alt="Web Tools Server MCP server" />
+</a>
+
 ### Requirements
 
 - Node.js 18+


### PR DESCRIPTION
This PR adds a badge for the [MCP Web Tools Server](https://glama.ai/mcp/servers/@JoaoPedroLanca/mcp-web-tools) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@JoaoPedroLanca/mcp-web-tools">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@JoaoPedroLanca/mcp-web-tools/badge" alt="Web Tools Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.